### PR TITLE
[Fastlane] Added support for `for_lane` method, when parsing an Appfile

### DIFF
--- a/lib/credentials_manager/appfile_config.rb
+++ b/lib/credentials_manager/appfile_config.rb
@@ -52,5 +52,16 @@ module CredentialsManager
       value ||= yield if block_given?
       data[:team_name] = value if value
     end
+
+    # Override Appfile configuration for a specific lane.
+    #
+    # lane_name  - String containing name for a lane.
+    # block - Block to execute to override configuration values.
+    #
+    # Discussion If received lane name does not match the lane name available as environment variable, this method
+    #             does nothing.
+    def for_lane(lane_name, &block)
+      block.call if lane_name == ENV["FASTLANE_LANE_NAME"] # If necessary, override the specified configurations.
+    end
   end
 end

--- a/lib/credentials_manager/appfile_config.rb
+++ b/lib/credentials_manager/appfile_config.rb
@@ -27,7 +27,7 @@ module CredentialsManager
       end
 
       # If necessary override per lane configuration
-      blocks[ENV["FASTLANE_LANE_NAME"].to_sym].call if blocks[ENV["FASTLANE_LANE_NAME"].to_sym]
+      blocks[ENV["FASTLANE_LANE_NAME"].to_sym].call if (ENV["FASTLANE_LANE_NAME"] && blocks[ENV["FASTLANE_LANE_NAME"].to_sym])
     end
 
     def blocks

--- a/lib/credentials_manager/appfile_config.rb
+++ b/lib/credentials_manager/appfile_config.rb
@@ -61,7 +61,7 @@ module CredentialsManager
     # Discussion If received lane name does not match the lane name available as environment variable, this method
     #             does nothing.
     def for_lane(lane_name, &block)
-      block.call if lane_name == ENV["FASTLANE_LANE_NAME"] # If necessary, override the specified configurations.
+      block.call if lane_name.to_s == ENV["FASTLANE_LANE_NAME"] # If necessary, override the specified configurations.
     end
   end
 end

--- a/spec/app_file_config_spec.rb
+++ b/spec/app_file_config_spec.rb
@@ -1,0 +1,39 @@
+require 'credentials_manager/appfile_config'
+
+describe CredentialsManager do
+  describe CredentialsManager::AppfileConfig do
+    describe "#load_for_lane_configuration" do
+      it "overrides Appfile configuration with current driven lane: beta" do
+        ENV["FASTLANE_LANE_NAME"] = :beta.to_s
+
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:app_identifier]).to eq('net.sunapps.1.beta')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:apple_id]).to eq('felix@sunapps.net')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:team_id]).to eq('3ECBP458CC')
+
+        ENV["FASTLANE_LANE_NAME"] = :enterprise.to_s
+
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:app_identifier]).to eq('enterprise.com')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:apple_id]).to eq('felix@sunapps.net')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:team_id]).to eq('Q2CBPJ58CC')
+      end
+    end
+
+    describe "#load_default_configuration_no_lane_found" do
+      it "loads Appfile default values for current driven lane if no override is found" do
+        ENV["FASTLANE_LANE_NAME"] = :this_is_not_something_you_find_in_the_app_file.to_s
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:app_identifier]).to eq('net.sunapps.1')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:apple_id]).to eq('felix@sunapps.net')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:team_id]).to eq('Q2CBPJ58CC')
+      end
+    end
+
+    describe "#load_default_configuration" do
+      it "loads Appfile default values if no any lane is found" do
+        ENV["FASTLANE_LANE_NAME"] = nil
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:app_identifier]).to eq('net.sunapps.1')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:apple_id]).to eq('felix@sunapps.net')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:team_id]).to eq('Q2CBPJ58CC')
+      end
+    end
+  end
+end

--- a/spec/fixtures/Appfile1
+++ b/spec/fixtures/Appfile1
@@ -1,0 +1,12 @@
+app_identifier "net.sunapps.1"
+apple_id "felix@sunapps.net"
+team_id "Q2CBPJ58CC"
+
+for_lane :beta do
+  app_identifier "net.sunapps.1.beta"
+  team_id "3ECBP458CC"
+end
+
+for_lane :enterprise do
+  app_identifier "enterprise.com"
+end


### PR DESCRIPTION
# Summary

Improve integration with Fastlane by overriding `Appfile` configurations declared for a specific lane.
# Why

An Appfile could include different configurations by specifying a lane name.
If configurations for a lane name matches current driven lane, specific configurations will be loaded.
# Example

Appfile as follow:

``` ruby
app_identifier "net.sunapps.1"
apple_id "felix@sunapps.net"
team_id "Q2CBPJ58CC"

for_lane :beta do
  app_identifier "net.sunapps.1.beta"
end

for_lane :enterprise do
  app_identifier "enterprise.com"
end
```

The value inside the blocks will be used if matches with current driven lane, otherwise the default configuration value will be loaded.
