### PR TITLE
Fixed issue that prevented to load proper `for_lane` configuration

### DIFF
--- a/lib/credentials_manager/appfile_config.rb
+++ b/lib/credentials_manager/appfile_config.rb
@@ -39,8 +39,8 @@ module CredentialsManager
       #
       # It is forbidden to specify multiple configuration for the same platform. It will raise an exception.
 
-      # Plaform specified.
       if for_platform_configuration?(blocks)
+        # Plaform specified.
         blocks[ENV["FASTLANE_PLATFORM_NAME"]].call
         inner_block = blocks[ENV["FASTLANE_PLATFORM_NAME"]]
         if for_lane_configuration?(inner_block)
@@ -116,8 +116,14 @@ module CredentialsManager
         blocks[lane_name.to_s] = block
       else
         if ENV["FASTLANE_LANE_NAME"]
-          # Platform and lane name specified, assigned lane configuration per different platforms
-          blocks[ENV["FASTLANE_PLATFORM_NAME"]] = {lane_name.to_s => block } if lane_name.to_s == ENV["FASTLANE_LANE_NAME"]
+          # The for_lane could be formatted as:
+          #   - only {lane_name} (i.e. 'for_lane beta ...')
+          #   - {platform_name} {lane_name} (i.e. 'for_lane "ios beta" ...')
+          #
+          # Either case it is a valid configuration to run the overwriting of the settings.
+          if lane_name.to_s == "#{ENV["FASTLANE_PLATFORM_NAME"]} #{ENV["FASTLANE_LANE_NAME"]}" || lane_name.to_s == ENV["FASTLANE_LANE_NAME"]
+             blocks[ENV["FASTLANE_LANE_NAME"]] = block
+          end
         end
       end
     end

--- a/spec/app_file_config_spec.rb
+++ b/spec/app_file_config_spec.rb
@@ -128,5 +128,23 @@ describe CredentialsManager do
         expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile1').data[:team_id]).to eq('Q2CBPJ58CC')
       end
     end
+
+    describe "#load_for_lane_configuration_with_specified_platform" do
+      it "overrides Appfile configuration with current platform and specified lane." do
+        ENV["FASTLANE_PLATFORM_NAME"] = :ios.to_s
+        ENV["FASTLANE_LANE_NAME"] = :beta.to_s
+
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile6').data[:apple_id]).to eq('felix@sunapps.net')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile6').data[:app_identifier]).to eq('com.app.beta')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile6').data[:team_id]).to eq('Q2CBPJ58CC')
+
+        ENV["FASTLANE_PLATFORM_NAME"] = :ios.to_s
+        ENV["FASTLANE_LANE_NAME"] = :enterprise.to_s
+
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile6').data[:apple_id]).to eq('felix@sunapps.net')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile6').data[:app_identifier]).to eq('enterprise.com')
+        expect(CredentialsManager::AppfileConfig.new('spec/fixtures/Appfile6').data[:team_id]).to eq('Q2CBPJ58AA')
+      end
+    end
   end
 end

--- a/spec/fixtures/Appfile6
+++ b/spec/fixtures/Appfile6
@@ -1,0 +1,12 @@
+app_identifier "net.sunapps.1"
+apple_id "felix@sunapps.net"
+team_id "Q2CBPJ58CC"
+
+for_lane "ios beta" do
+  app_identifier "com.app.beta"
+end
+
+for_lane "ios enterprise" do
+  team_id "Q2CBPJ58AA"
+  app_identifier "enterprise.com"
+end


### PR DESCRIPTION
# Summary

Fixes issue where wrong configurations were loaded, in case the Appfile has a `for_lane` declaration formatted as :

 `for_lane "{platform_name} {lane_name}"`
# Notes
- This solves Fastlane's issue: https://github.com/KrauseFx/fastlane/issues/456#issuecomment-128012881
- An [updated](https://github.com/KrauseFx/fastlane/pull/476) version of the docs for Fastlane gives a better overview of usage and limitations 
