### PR TITLE
store shared instance by user id

### DIFF
--- a/lib/credentials_manager/password_manager.rb
+++ b/lib/credentials_manager/password_manager.rb
@@ -17,11 +17,12 @@ module CredentialsManager
     # @param id_to_use (String) The Apple ID email address which should be used
     # @param ask_if_missing (boolean) true by default: if no credentials are found, should the user be asked?
     def self.shared_manager(id_to_use = nil, ask_if_missing = true)
-      @@instance ||= PasswordManager.new(id_to_use, ask_if_missing)
+      @instance ||= {}
+      @instance[id_to_use] ||= PasswordManager.new(id_to_use, ask_if_missing)
     end
 
     def self.logout
-      @@instance = nil
+      @instance = nil
     end
 
     # A new instance of PasswordManager.


### PR DESCRIPTION
This fixes a bug that happens since the shared manager is only instantiated on first use _with the `id_to_use` used on first access. If you pass a different `id_to_use` later you will get the wrong data from the previously instantiated manager.

In general I feel a parametrized shared singleton is really not a great idea. Maybe the classes using this should just instantiate their own instance instead and the `share_manager` should be deprecated? 
