### PR TITLE
Allow to specify the country in the Appfile

### DIFF
--- a/lib/credentials_manager/appfile_config.rb
+++ b/lib/credentials_manager/appfile_config.rb
@@ -41,39 +41,19 @@ module CredentialsManager
     # Setters
 
     def app_identifier(*args, &_block)
-      if block_given?
-        value = yield
-      else
-        value = args.shift
-      end
-      data[:app_identifier] = value if value
+      setter(:app_identifier, *args, &_block)
     end
 
     def apple_id(*args, &_block)
-      if block_given?
-        value = yield
-      else
-        value = args.shift
-      end
-      data[:apple_id] = value if value
+      setter(:apple_id, *args, &_block)
     end
 
     def team_id(*args, &_block)
-      if block_given?
-        value = yield
-      else
-        value = args.shift
-      end
-      data[:team_id] = value if value
+      setter(:team_id, *args, &_block)
     end
 
     def team_name(*args, &_block)
-      if block_given?
-        value = yield
-      else
-        value = args.shift
-      end
-      data[:team_name] = value if value
+      setter(:team_name, *args, &_block)
     end
 
     # Override Appfile configuration for a specific lane.
@@ -110,6 +90,17 @@ module CredentialsManager
       if ENV["FASTLANE_PLATFORM_NAME"] == platform_name.to_s
         block.call
       end
+    end
+
+    private
+
+    def setter(key, *args, &_block)
+      if block_given?
+        value = yield
+      else
+        value = args.shift
+      end
+      data[key] = value if value
     end
   end
 end

--- a/lib/credentials_manager/appfile_config.rb
+++ b/lib/credentials_manager/appfile_config.rb
@@ -56,6 +56,10 @@ module CredentialsManager
       setter(:team_name, *args, &_block)
     end
 
+    def country(*args, &_block)
+      setter(:country, *args, &_block)
+    end
+
     # Override Appfile configuration for a specific lane.
     #
     # lane_name  - Symbol representing a lane name. (Can be either :name, 'name' or 'platform name')


### PR DESCRIPTION
For those users who do not have their app in the US appstore, we added support for the country argument. I would also like this info to be in the Appfile and supported by all tools.

Not really sure if country is a good name.
Maybe appstore_country or app_country is better. Please comment
